### PR TITLE
KEEP-1 Keepa API supports mutiple productTypes

### DIFF
--- a/keepa/query_keys.py
+++ b/keepa/query_keys.py
@@ -998,7 +998,7 @@ PRODUCT_REQUEST_KEYS = {
     'perPage': int,
     'platform': list,
     'productGroup': list,
-    'productType': int,
+    'productType': list,
     'promotions': int,
     'publicationDate_lte': int,
     'publicationDate_gte': int,


### PR DESCRIPTION
The interface should accept a list to allow for more than one product
type. Currently, there are 3 supported option types: 0 (stanard),
1 (downloadable), and 5 (variation_parent)
retry attempts are reached